### PR TITLE
Episode number hash override and text appended to title via metadata file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Scanner and Metadata Agent for Plex that uses www.thesportsdb.com
 
-#Installation
+# Installation
 
 Plex main folder location:
 
@@ -31,11 +31,11 @@ Plex main folder location:
  - You may need to restart Plex
  - Create a new library and under Advanced options you should be able to select "SportScanner" as both your scanner and metadata agent.
 
-#Media Format
+# Media Format
 
 The SportScanner scanner requires one of two folder structures to work correctly, the first of which matches Plex's standard folder structure.
 
-##RECOMMENDED METHOD
+## RECOMMENDED METHOD
 
 Follow the Plex standards for folder structure - TV Show\Season\<files>. For SportScanner, TV Shows = League Name. For example for 2015/2016 NHL you would do something like the following:
 
@@ -43,7 +43,7 @@ Follow the Plex standards for folder structure - TV Show\Season\<files>. For Spo
 
 In this scenario you still need all the information in the file name, I aim to remove that requirement down the line. The only information that comes only from the folder structure is the season. 
 
-##Alternative naming standard
+## Alternative naming standard
 
 You can also choose to ignore the season directory and have the scanner work it out with a folder structure like so:
 
@@ -64,12 +64,12 @@ SportScanner does not actually pay attention to the name of the League directory
 
 This is rubbish, it kind of accidentally works, I don't recommend it as I will cut it out as part of improvement works in future.
 
-#Known Issues
+# Known Issues
  - No posters for seasons
  - Can only handle individual files, not multipart or those in folders
  - All information must be in the filename regardless of the directory structure.
 
-#Additional Metadata
+# Additional Metadata
 
 The presence of a .SportScanner metadata file can be used to append additional text to the title of the event as well as override a portion of the episode number.
 Normally the episode number is of the form `YYMMDDHHHH` where YY is the year, MM is the month, DD is the day, and HHHH is based on a hash.  If the first line of the `.SportScanner` file is a number it will be used in place of the hash.

--- a/README.md
+++ b/README.md
@@ -75,5 +75,14 @@ The presence of a .SportScanner metadata file can be used to append additional t
 Normally the episode number is of the form `YYMMDDHHHH` where YY is the year, MM is the month, DD is the day, and HHHH is based on a hash.  If the first line of the `.SportScanner` file is a number it will be used in place of the hash.
 The second line of the `.SportScanner` file will be appended to the title of the event.
 
- - ~LibraryRoot/NHL/Season 1516/NHL.2015.09.25.New-York-Islanders.vs.Philadelphia-Flyers.720p.HDTV.60fps.x264-Reborn4HD_h.mp4
- - ~LibraryRoot/NHL/Season 1516/NHL.2015.09.25.New-York-Islanders.vs.Philadelphia-Flyers.720p.HDTV.60fps.x264-Reborn4HD_h.SportScanner
+ - ~LibraryRoot/Formula 1/Season 2019/Formula 1 2019-06-30 Austrian Grand Prix - 03 Post-Race Analysis.mp4
+ - ~LibraryRoot/Formula 1/Season 2019/Formula 1 2019-06-30 Austrian Grand Prix - 03 Post-Race Analysis.SportScanner
+
+In the above example, the `Formula 1 2019-06-30 Austrian Grand Prix - 03 Post-Race Analysis.SportScanner` file contains the following text:
+
+```
+3
+(Post-Race Analysis)
+```
+
+The resulting episode number is `1906300003` and the resulting title is `Austrian Grand Prix (Post-Race Analysis)`

--- a/README.md
+++ b/README.md
@@ -68,3 +68,12 @@ This is rubbish, it kind of accidentally works, I don't recommend it as I will c
  - No posters for seasons
  - Can only handle individual files, not multipart or those in folders
  - All information must be in the filename regardless of the directory structure.
+
+#Additional Metadata
+
+The presence of a .SportScanner metadata file can be used to append additional text to the title of the event as well as override a portion of the episode number.
+Normally the episode number is of the form `YYMMDDHHHH` where YY is the year, MM is the month, DD is the day, and HHHH is based on a hash.  If the first line of the `.SportScanner` file is a number it will be used in place of the hash.
+The second line of the `.SportScanner` file will be appended to the title of the event.
+
+ - ~LibraryRoot/NHL/Season 1516/NHL.2015.09.25.New-York-Islanders.vs.Philadelphia-Flyers.720p.HDTV.60fps.x264-Reborn4HD_h.mp4
+ - ~LibraryRoot/NHL/Season 1516/NHL.2015.09.25.New-York-Islanders.vs.Philadelphia-Flyers.720p.HDTV.60fps.x264-Reborn4HD_h.SportScanner

--- a/Scanners/Series/SportScanner.py
+++ b/Scanners/Series/SportScanner.py
@@ -61,6 +61,22 @@ def Scan(path, files, mediaList, subdirs):
         # These files have been dumped into a League directory but have no seasons.
         for file in clean_files:
             print "SS: Working on file | {0} |".format(file)
+
+            # jump in here for some additional metadata logic
+            additional_metadata_file = os.path.splitext(clean_files[file])[0] + '.SportScanner'
+            additional_metadata_subepisode = '';
+            if os.path.isfile(additional_metadata_file):
+                additional_metadata_size = os.path.getsize(additional_metadata_file)
+                additional_metadata_fd = os.open(additional_metadata_file, os.O_RDONLY)
+                additional_metadata_lines = os.read(additional_metadata_fd, additional_metadata_size).splitlines()
+                os.close(additional_metadata_fd)
+                if len(additional_metadata_lines) > 0:
+                    additional_metadata_subepisode = additional_metadata_lines[0]
+            try:
+                additional_metadata_subepisode = int(additional_metadata_subepisode)
+            except ValueError:
+                additional_metadata_subepisode = -1
+
             for rx in regex_all_in_file_name:
                 match = re.search(rx, file, re.IGNORECASE)
                 if match:
@@ -115,7 +131,10 @@ def Scan(path, files, mediaList, subdirs):
 
                     # Using a hash so that each file gets the same episode number on every scan
                     # The year must be included for seasons that run over a year boundary
-                    ep = int('%s%02d%02d%04d' % (year[-2:],month, day, abs(hash(file)) % (10 ** 4)))
+                    if additional_metadata_subepisode < 0:
+                        ep = int('%s%02d%02d%04d' % (year[-2:],month, day, abs(hash(file)) % (10 ** 4)))
+                    else:
+                        ep = int('%s%02d%02d%04d' % (year[-2:],month, day, additional_metadata_subepisode))
                     tv_show = Media.Episode(show, season, ep, title, int(year))
                     tv_show.released_at = '%s-%02d-%02d' % (year, month, day)
                     tv_show.parts.append(clean_files[file])
@@ -140,6 +159,22 @@ def Scan(path, files, mediaList, subdirs):
         # Look for ALL the information we need in the filename - but trust what we have already found
         for file in clean_files:
             print "SS: Working on file | {0} |".format(file)
+            
+            # jump in here for some additional metadata logic
+            additional_metadata_file = os.path.splitext(clean_files[file])[0] + '.SportScanner'
+            additional_metadata_subepisode = '';
+            if os.path.isfile(additional_metadata_file):
+                additional_metadata_size = os.path.getsize(additional_metadata_file)
+                additional_metadata_fd = os.open(additional_metadata_file, os.O_RDONLY)
+                additional_metadata_lines = os.read(additional_metadata_fd, additional_metadata_size).splitlines()
+                os.close(additional_metadata_fd)
+                if len(additional_metadata_lines) > 0:
+                    additional_metadata_subepisode = additional_metadata_lines[0]
+            try:
+                additional_metadata_subepisode = int(additional_metadata_subepisode)
+            except ValueError:
+                additional_metadata_subepisode = -1
+            
             for rx in regex_all_in_file_name:
                 match = re.search(rx, file, re.IGNORECASE)
                 if match:
@@ -151,7 +186,10 @@ def Scan(path, files, mediaList, subdirs):
 
                     # Using a hash so that each file gets the same episode number on every scan
                     # The year must be included for seasons that run over a year boundary
-                    ep = int('%s%02d%02d%04d' % (year[-2:],month, day, abs(hash(file)) % (10 ** 4)))
+                    if additional_metadata_subepisode < 0:
+                        ep = int('%s%02d%02d%04d' % (year[-2:],month, day, abs(hash(file)) % (10 ** 4)))
+                    else:
+                        ep = int('%s%02d%02d%04d' % (year[-2:],month, day, additional_metadata_subepisode))
                     tv_show = Media.Episode(show, season, ep, title, int(year))
                     tv_show.released_at = '%s-%02d-%02d' % (year, month, day)
                     tv_show.parts.append(clean_files[file])

--- a/SportScanner.bundle/Contents/Code/__init__.py
+++ b/SportScanner.bundle/Contents/Code/__init__.py
@@ -227,6 +227,18 @@ class SportScannerAgent(Agent.TV_Shows):
                         matched_episode = None
                         # First try and match the filename exactly as it is
 
+                        # jump in here for some additional metadata logic
+                        additional_metadata_file = os.path.splitext(episode_media.items[0].parts[0].file)[0] + '.SportScanner'
+                        additional_metadata_subtitle = '';
+                        if os.path.isfile(additional_metadata_file):
+                            additional_metadata_size = os.path.getsize(additional_metadata_file)
+                            additional_metadata_fd = os.open(additional_metadata_file, os.O_RDONLY)
+                            additional_metadata_lines = os.read(additional_metadata_fd, additional_metadata_size).splitlines()
+                            os.close(additional_metadata_fd)
+                            if len(additional_metadata_lines) > 1:
+                                additional_metadata_subtitle = additional_metadata_lines[1]
+                        additional_metadata_subtitle = additional_metadata_subtitle.strip()
+
                         filename = os.path.splitext(os.path.basename(episode_media.items[0].parts[0].file))[0]
                         whackRx = ['([hHx][\.]?264)[^0-9].*', '[^[0-9](720[pP]).*', '[^[0-9](1080[pP]).*',
                                    '[^[0-9](480[pP]).*', '[^[0-9](540[pP]).*']
@@ -317,7 +329,10 @@ class SportScannerAgent(Agent.TV_Shows):
                             return
 
                         Log("SS: Updating metadata for {0}".format(matched_episode['strEvent']))
-                        episode.title = matched_episode['strEvent']
+                        if len(additional_metadata_subtitle) > 0:
+                            episode.title = matched_episode['strEvent'] + ' ' + additional_metadata_subtitle
+                        else:
+                            episode.title = matched_episode['strEvent']
                         #Generate a useful description based on the available fields
                         extra_details = ""
                         if matched_episode['strAwayTeam'] is not None and matched_episode['strHomeTeam'] is not None:


### PR DESCRIPTION
I closed my other pull request and shifted to a feature branch so my other improvement can be considered separately without issue.

This is a change I made for my own personal use but I wanted to offer it back to the main code base. You can close this request without comment if you would not like to include this feature. I am not specifically a python developer but I have tested this code to ensure it operates properly in the conditions I've run into.

This change allows for a metadata file with the .SportScanner extension to override the hash portion of the episode number in the scanner and dynamically append to the title of the event in the metadata agent. I utilize this to handle events split into multiple portions, such as the pre and post game shows, preserving their order and adding context to the title as needed. The file is two lines of text (or less) where the first line is the override episode number and the second line is the text to be appended to the title.