### PR TITLE
Provide ability to use Personal API Key at TheSportsDB.com + small fixes

### DIFF
--- a/SportScanner.bundle/Contents/Code/__init__.py
+++ b/SportScanner.bundle/Contents/Code/__init__.py
@@ -110,6 +110,7 @@ class SportScannerAgent(Agent.TV_Shows):
         try:
             potential_leagues = (JSON.ObjectFromString(GetResultFromNetwork(url, True)))['leagues']
         except:
+            potential_leagues = None
             Log("SS: Could not retrieve shows from thesportsdb.com")
 
         match = False

--- a/SportScanner.bundle/Contents/Code/__init__.py
+++ b/SportScanner.bundle/Contents/Code/__init__.py
@@ -99,6 +99,8 @@ def Start():
 class SportScannerAgent(Agent.TV_Shows):
     name = 'SportScanner'
     languages = ['en']
+    primary_provider = True
+    fallback_provider = ['com.plexapp.agents.localmedia']
     accepts_from = ['com.plexapp.agents.localmedia']
     cached_leagues = {}  # We will use this in the next step. This will remove an additional API call for every sport.
 

--- a/SportScanner.bundle/Contents/Code/__init__.py
+++ b/SportScanner.bundle/Contents/Code/__init__.py
@@ -4,6 +4,12 @@ from difflib import SequenceMatcher
 import urllib2
 import certifi
 import requests
+import ConfigParser
+
+config = ConfigParser.SafeConfigParser()
+config.add_section('thesportsdb.com')
+config.set('thesportsdb.com','apikey','8123456712556')
+configread = config.read('SportsScanner.ini')
 
 netLock = Thread.Lock()
 
@@ -16,7 +22,7 @@ RETRY_TIMEOUT = MIN_RETRY_TIMEOUT
 TOTAL_TRIES = 1
 BACKUP_TRIES = -1
 
-SPORTSDB_API = "https://www.thesportsdb.com/api/v1/json/8123456712556/"
+SPORTSDB_API = "https://www.thesportsdb.com/api/v1/json/{0}/".format(config.get('thesportsdb.com','apikey'))
 
 headers = {'User-agent': 'Plex/Nine'}
 


### PR DESCRIPTION
If the user has a personal API key at TheSportsDB.com, a file (not created by default) can be placed in the agent data directory (on Linux, "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-in Support/Data/com.plexapp.agents.sportscanner/SportsScanner.ini"

The contents of the file can be:
```
[thesportsdb.com]
apikey=2
```
With your personal API key (2 is the test key), Code will still use the SportsScanner API key by default if the file does not exist. In this way, the code supports using a personal key without having to edit the code base.

Other changes:
use the localmedia agent as a fallback with SportsScanner as primary (ef0e264)
avoid uninitialized errors on the potential_leagues variable on failures (fdc11d7)