### PR TITLE
Make search for SportScanner.txt OS independent.  Issue #26

### DIFF
--- a/Scanners/Series/SportScanner.py
+++ b/Scanners/Series/SportScanner.py
@@ -92,7 +92,7 @@ def Scan(path, files, mediaList, subdirs):
                         season = year
 
                     # Work out where the .SportScanner file should be
-                    filename = re.sub(r'(.*\\).*?$',r'\1SportScanner.txt',clean_files[file])
+                    filename = "{0}{1}SportScanner.txt".format(os.path.dirname(clean_files[file]),os.path.sep)
                     print "SS: FileName: {0}".format(filename)
 
                     # Check to see if a .SportScanner file exists, then read in the contents


### PR DESCRIPTION
The code to look for the SportScanner.txt is Windows dependent.  This change uses the python libraries to make the search work on any OS.

The consequence of this was that on Linux, the read of the SportScanner.txt file was actually reading EVERY video file and looking for the XXYY text.  We never knew that until I looked at Issue #26 and realized that he was crashing because the file he was reading was so large.