### PR TITLE
Fix the API Key issue

### DIFF
--- a/SportScanner.bundle/Contents/Code/__init__.py
+++ b/SportScanner.bundle/Contents/Code/__init__.py
@@ -12,14 +12,14 @@ try:
 except ImportError:
     sportsdb = ''
 try:
-    sportsdb = base64.b64decode(thesportsdb.sportsdb.encode('ascii')).decode('ascii')
+    sportsdb = ''.join(map(str,[chr(ord(a) ^ ord(b)) for a,b in zip (base64.b64decode(thesportsdb.sportsdbkey1),base64.b64decode(thesportsdb.sportsdbkey2))]))
 except AttributeError:
     sportsdb = ''
 
 config = ConfigParser.SafeConfigParser()
 config.add_section('thesportsdb.com')
 config.set('thesportsdb.com','apikey',sportsdb)
-configread = config.read('SportsScanner.ini')
+_ = config.read('SportsScanner.ini')
 
 netLock = Thread.Lock()
 

--- a/SportScanner.bundle/Contents/Code/__init__.py
+++ b/SportScanner.bundle/Contents/Code/__init__.py
@@ -5,10 +5,20 @@ import urllib2
 import certifi
 import requests
 import ConfigParser
+import base64
+
+try:
+    import thesportsdb
+except ImportError:
+    sportsdb = ''
+try:
+    sportsdb = base64.b64decode(thesportsdb.sportsdb.encode('ascii')).decode('ascii')
+except AttributeError:
+    sportsdb = ''
 
 config = ConfigParser.SafeConfigParser()
 config.add_section('thesportsdb.com')
-config.set('thesportsdb.com','apikey','8123456712556')
+config.set('thesportsdb.com','apikey',sportsdb)
 configread = config.read('SportsScanner.ini')
 
 netLock = Thread.Lock()
@@ -236,7 +246,7 @@ class SportScannerAgent(Agent.TV_Shows):
                     episode_media = media.seasons[s].episodes[e]
 
                     @task
-                    def UpdateEpisode(episode=episode, league_metadata=league_metadata, episode_media=episode_media, metadata=metadata):
+                    def UpdateEpisode(e=e, episode=episode, league_metadata=league_metadata, episode_media=episode_media, metadata=metadata):
                         Log("SS: Matching episode number {0}: {1}".format(e, episode_media.title))
                         matched_episode = None
                         # First try and match the filename exactly as it is

--- a/SportScanner.bundle/Contents/Code/thesportsdb.py
+++ b/SportScanner.bundle/Contents/Code/thesportsdb.py
@@ -1,1 +1,3 @@
-sportsdb = 'ODEyMzQ1NjcxMjU1Ng=='
+sportsdbkey1 = 'AAsAAQIFBQ=='
+sportsdbkey2 = 'MTIzNDU2Nw=='
+

--- a/SportScanner.bundle/Contents/Code/thesportsdb.py
+++ b/SportScanner.bundle/Contents/Code/thesportsdb.py
@@ -1,0 +1,1 @@
+sportsdb = 'ODEyMzQ1NjcxMjU1Ng=='


### PR DESCRIPTION
This PR will fix Issue #35 .  A default SportScanner key has been enabled and will be used, but this code will also allow a user to use a personal key that they have stored in SportScanner.ini.

This code has been reviewed with zag@thedatadb

Thanks to Zag for providing all SS users with the access to pull data!